### PR TITLE
Update Django version to remove security vulnerability

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,3 +1,3 @@
-Django==2.0.7
+Django==2.0.9
 pytest-bdd==2.21.0
 pytest-mock==1.10.0

--- a/service_builder/templates/requirements/base.txt
+++ b/service_builder/templates/requirements/base.txt
@@ -1,4 +1,4 @@
-Django==2.0.7
+Django==2.0.9
 django-filter==2.0.0
 django-health-check==3.6.1
 git+https://github.com/Humanitec/django-oauth-toolkit-jwt@v0.4.0#egg=django-oauth-toolkit-jwt

--- a/service_builder/tests/test_setup_service.py
+++ b/service_builder/tests/test_setup_service.py
@@ -67,7 +67,7 @@ class SetupTest(TestCase):
         with open(file_base, 'r') as fp:
             content = fp.read()
         self.assertEqual(content, """\
-Django==2.0.7
+Django==2.0.9
 django-filter==2.0.0
 django-health-check==3.6.1
 git+https://github.com/Humanitec/django-oauth-toolkit-jwt@v0.4.0#egg=django-oauth-toolkit-jwt


### PR DESCRIPTION
## Purpose
There's a security vulnerability in the current version of Django. django.middleware.common.CommonMiddleware in Django 1.11.x before 1.11.15 and 2.0.x before 2.0.8 has an Open Redirect.

## Approach
- Updated Django version from `2.0.7` to `2.0.9`